### PR TITLE
Replace deprecated `\ior_get_str:NN` with `\ior_str_get:NN`.

### DIFF
--- a/sdapsarray.dtx
+++ b/sdapsarray.dtx
@@ -157,7 +157,7 @@
 {
   \bool_gset_eq:NN #1 \c_false_bool
   \ior_if_eof:NF \g__sdaps_array_info_ior {
-    \ior_get_str:NN \g__sdaps_array_info_ior \l_tmpa_tl
+    \ior_str_get:NN \g__sdaps_array_info_ior \l_tmpa_tl
 
     \tl_if_eq:NNF \g__sdaps_array_last_row_tl \c_empty_tl {
       \tl_if_eq:NNF \g__sdaps_array_last_row_tl \l_tmpa_tl {


### PR DESCRIPTION
I noticed that the sdaps class doesn't compile on current TeXLive versions. The error helpfully suggests a solution:
```
LaTeX error: "kernel/deprecated-command" The deprecated command '\ior_get_str:NN' has been or will be removed on 2018-03-05. Use instead '\ior_str_get:NN'.
```
This PR implements this suggestion.