### PR TITLE
Replace deprecated \box_use_clear:N with \box_use_drop:N

### DIFF
--- a/sdapsarray.dtx
+++ b/sdapsarray.dtx
@@ -684,7 +684,7 @@
     % placing that into it again ...
     \box_use:N \l_tmpa_box
   }
-  \hcoffin_set:Nn \l_tmpa_coffin { \box_use_clear:N #2 }
+  \hcoffin_set:Nn \l_tmpa_coffin { \box_use_drop:N #2 }
 
   \seq_gconcat:NNN \g_sdaps_array_shared_colwidths_seq \g_tmpa_seq \g_sdaps_array_shared_colwidths_seq
   \seq_gclear:N \g_tmpa_seq


### PR DESCRIPTION
As discussed in the chat `\box_use_clear:N` was renamed in 2017 so this should be safe to change.

See https://github.com/latex3/latex3/commit/a5abd83b4ca08d01c1520354b33cfd1bcd667958